### PR TITLE
Fix bolt handling

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-mod_version=2.1.7
+mod_version=2.1.8
 minecraft_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 tconstruct_version=1.8.4.build951

--- a/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ModPartReplacement.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ModPartReplacement.java
@@ -10,6 +10,7 @@ import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.crafting.ToolRecipe;
 import tconstruct.library.modifier.ItemModifier;
+import tconstruct.library.tools.DualMaterialToolPart;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.library.util.IToolPart;
 import tconstruct.tools.TinkerTools;
@@ -45,7 +46,7 @@ public class ModPartReplacement extends ItemModifier {
             return false;
 
         // check if any of the tools parts contain stone. we have to prevent exchanging that with disabled stone tools
-        // because otherwise the replacement-logic would not be able to obtain neccessary information and crash.
+        // because otherwise the replacement-logic would not be able to obtain necessary information and crash.
         if(Config.disableStoneTools)
         {
             if(tool.getHeadItem() != null && getToolPartMaterial(tags, HEAD) == 1)
@@ -134,6 +135,7 @@ public class ModPartReplacement extends ItemModifier {
                 return false;
 
         // do we have enough modifiers left if we exchange this part?
+        // This probably doesn't work right for bolts (which replace two parts at a time).
         if(hasExtraModifier(oldMatId)) // paper or thaumium. sadly hardcoded.
             modifiers--;
         if(hasExtraModifier(newMatId))
@@ -142,8 +144,18 @@ public class ModPartReplacement extends ItemModifier {
             return false;
 
         // is it the same material as the one we want to replace?
-        if(newMatId == oldMatId)
+        if (newMatId == oldMatId) {
+            // Special case for bolts, which have two materials.
+            if (tool == TinkerWeaponry.boltAmmo && replacementPartItem instanceof DualMaterialToolPart) {
+                int newHeadMatId =
+                        ((DualMaterialToolPart) replacementPartItem).getMaterialID2(parts[partIndex]);
+                int oldHeadMatId = getToolPartMaterial(tags, HEAD);
+
+                return newHeadMatId != oldHeadMatId;
+            }
+
             return false;
+        }
 
         return true;
     }

--- a/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
@@ -123,6 +123,7 @@ public final class ReplacementLogic {
 
         // update damage
         updateTag(newTags, tags, "Attack");
+        updateTag(newTags, tags, "BaseAttack");
 
         // update mining speed
         updateTag(newTags, tags, "MiningSpeed");


### PR DESCRIPTION
This PR includes two fixes for part replacement:
 * When checking for different materials, bolt head material will now be checked. Previously, only shaft material was checked, so it was not possible to replace a bolt core when changing only the head material.
 * Fix for incorrect damage calculation in new tool for projectiles (arrows, bolts, javelins, etc.). Previously, the `"BaseAttack"` NBT tag was not getting copied over; this tag is used for projectile damage calculations. This should fix cases where replacing a bolt core resulted in a substantially lower-damage bolt than creating a new bolt.

Note that this PR will break part replacement (cause a crash to desktop) for any tools that are missing the `"BaseAttack"` NBT tag. That tag was added in this commit in 2015:
 * https://github.com/GTNewHorizons/TinkersConstruct/commit/283c3cf12a09aa1c6ca2ef2435a0519b863ccb41

so tools created before that commit will break. Let me know if you'd like me to add in a check for this case.