### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/iguanatweakstconstruct/lang/en_US.lang
+++ b/src/main/resources/assets/iguanatweakstconstruct/lang/en_US.lang
@@ -271,6 +271,8 @@ item.iguana.tcon.wearable.clayBucketCracked.name=Cracked Clay Bucket
 item.iguana.tcon.wearable.endermanJaw.name=Enderman Jaw
 item.iguana.tcon.wearable.bathat.name=Bat Hat
 
+item.iguana.tcon.rubberChicken.name=Rubber Chicken
+
 tooltip.bucketHoley=A bucket with holes. How useful.
 tooltip.clayBucketCracked=It broke. :(
 tooltip.endermanJaw=A distinct lack of head is noticeable.


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.