### PR TITLE
fix: make the easy tool repair compatible with TGregworks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,6 +3,7 @@
 dependencies {
     api("com.github.GTNewHorizons:TinkersConstruct:1.13.38-GTNH:dev")
     api("com.github.GTNewHorizons:NotEnoughItems:2.7.57-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:TinkersGregworks:GTNH-1.0.27:dev")
     compileOnly("com.github.GTNewHorizons:Railcraft:9.16.30:dev")
     compileOnly("com.github.GTNewHorizons:BuildCraft:7.1.43:dev")
 

--- a/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/RepairCraftingRecipe.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/RepairCraftingRecipe.java
@@ -7,7 +7,6 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 import net.minecraftforge.oredict.RecipeSorter;
 
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import iguanaman.iguanatweakstconstruct.reference.Reference;
 import tconstruct.library.crafting.ModifyBuilder;

--- a/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/RepairCraftingRecipe.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/RepairCraftingRecipe.java
@@ -1,6 +1,5 @@
 package iguanaman.iguanatweakstconstruct.tweaks;
 
-import iguanaman.iguanatweakstconstruct.util.ModSupportHelper;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
@@ -9,6 +8,7 @@ import net.minecraftforge.oredict.RecipeSorter;
 
 import cpw.mods.fml.common.Optional;
 import iguanaman.iguanatweakstconstruct.reference.Reference;
+import iguanaman.iguanatweakstconstruct.util.ModSupportHelper;
 import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.library.modifier.ItemModifier;
 import tconstruct.library.tools.ToolCore;

--- a/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/RepairCraftingRecipe.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/RepairCraftingRecipe.java
@@ -1,5 +1,6 @@
 package iguanaman.iguanatweakstconstruct.tweaks;
 
+import iguanaman.iguanatweakstconstruct.util.ModSupportHelper;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
@@ -30,10 +31,9 @@ public class RepairCraftingRecipe implements IRecipe {
     private ItemStack modifiedTool = null;
 
     public RepairCraftingRecipe() {
-        boolean gregworksLoaded = Loader.isModLoaded("TGregworks");
         for (ItemModifier mod : ModifyBuilder.instance.itemModifiers) {
             // If TGregworks is present, use ModTGregRepair instead of ModToolRepair
-            if (gregworksLoaded && isTGregRepairModifier(mod)) {
+            if (ModSupportHelper.TGregworks && isTGregRepairModifier(mod)) {
                 modifier = mod;
                 break;
             } else if (mod instanceof ModToolRepair) {

--- a/src/main/java/iguanaman/iguanatweakstconstruct/util/ModSupportHelper.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/util/ModSupportHelper.java
@@ -13,6 +13,7 @@ public final class ModSupportHelper {
     public static final boolean Metallurgy = Loader.isModLoaded("Metallurgy");
     public static final boolean Natura = Loader.isModLoaded("Natura");
     public static final boolean AppliedEnergistics2 = Loader.isModLoaded("appliedenergistics2");
+    public static final boolean TGregworks = Loader.isModLoaded("TGregworks");
 
     public static final boolean ThermalFoundation = Loader.isModLoaded("ThermalFoundation");
 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20961
Crash caused by a regression in https://github.com/Vexatos/TinkersGregworks/pull/61, no ModToolRepair was available while loading the recipe, which caused an NPE.

One of my first contribution, I'd be glad to have some feedback, was unsure about the actual check but it fixes the bug for me.

