### PR TITLE
Config option to allow fake players

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/LevelingActiveToolMod.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/LevelingActiveToolMod.java
@@ -16,6 +16,7 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import iguanaman.iguanatweakstconstruct.IguanaTweaksTConstruct;
 import iguanaman.iguanatweakstconstruct.leveling.modifiers.ModCritical;
+import iguanaman.iguanatweakstconstruct.reference.Config;
 import tconstruct.library.ActiveToolMod;
 import tconstruct.library.tools.HarvestTool;
 import tconstruct.library.tools.ToolCore;
@@ -29,8 +30,8 @@ public class LevelingActiveToolMod extends ActiveToolMod {
     @Override
     public boolean beforeBlockBreak(ToolCore tool, ItemStack stack, int x, int y, int z, EntityLivingBase entity) {
         if (!(entity instanceof EntityPlayer)) return false;
-        // nope, you don't use an autonomous activator!
-        if (entity instanceof FakePlayer) return false;
+        // nope, you don't use an autonomous activator! Or you do, depending on your config...
+        if (entity instanceof FakePlayer && !Config.allowFakePlayerLeveling) return false;
         // why are you breaking this block with that tool! It's not a harvest tool derp!
         if (!(tool instanceof HarvestTool)) return false;
 

--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
@@ -48,8 +48,7 @@ public class LevelingEventHandler {
         // only players
         if (!(event.source.getEntity() instanceof EntityPlayer)) return;
         EntityPlayer player = (EntityPlayer) event.source.getEntity();
-        // but no fake players
-        if (player instanceof FakePlayer) return;
+        if (player instanceof FakePlayer && !Config.allowFakePlayerLeveling) return;
 
         ItemStack stack = player.getCurrentEquippedItem();
         if (event.source.getSourceOfDamage() instanceof ShurikenEntity) {
@@ -142,8 +141,7 @@ public class LevelingEventHandler {
     @SubscribeEvent
     public void onUseHoe(UseHoeEvent event) {
         EntityPlayer player = event.entityPlayer;
-        // no fake players
-        if (player instanceof FakePlayer) return;
+        if (player instanceof FakePlayer && !Config.allowFakePlayerLeveling) return;
 
         // can hoe?
         Block block = event.world.getBlock(event.x, event.y, event.z);

--- a/src/main/java/iguanaman/iguanatweakstconstruct/mobheads/handlers/MobHeadHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/mobheads/handlers/MobHeadHandler.java
@@ -42,10 +42,11 @@ public class MobHeadHandler {
             }
         }
 
-        // add our own drops if the damage source was a player (and no fake player)
+        // add our own drops if the damage source was a (fake) player
         Entity entity = event.source.getEntity();
         if (entity == null) return;
-        if (!(entity instanceof EntityPlayer) || entity instanceof FakePlayer) return;
+        if (!(entity instanceof EntityPlayer)) return;
+        if (entity instanceof FakePlayer && !Config.headsFromFakePlayerKills) return;
 
         // how much beheading chance do we have?
         EntityPlayer player = (EntityPlayer) event.source.getEntity();

--- a/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
@@ -32,6 +32,7 @@ public class Config {
     public static boolean randomBonusesAreUseful;
     public static boolean randomBonusesAreRandom;
     public static boolean onlyHeadsChangeXPRequirement;
+    public static boolean allowFakePlayerLeveling;
 
     // random bonuses deactivation
     public static Set<RandomBonuses.Modifier> deactivatedModifiers = new HashSet<RandomBonuses.Modifier>();
@@ -57,6 +58,7 @@ public class Config {
     // heads
     public static int baseHeadDropChance;
     public static int beheadingHeadDropChance;
+    public static boolean headsFromFakePlayerKills;
 
     // tweaks
     public static boolean nerfVanillaTools;
@@ -147,6 +149,11 @@ public class Config {
                 CATEGORY_Leveling,
                 true,
                 "If true, only the heads of tools are examined when determining how much XP it takes to level up. (This only matters if you manually specify that some material types level faster than others using the override module)");
+        allowFakePlayerLeveling = configfile.getBoolean(
+                "allowFakePlayerLeveling",
+                CATEGORY_Leveling,
+                false,
+                "Allow tool leveling through fake players");
 
         // tooltip things
         showTooltipXP = configfile
@@ -310,6 +317,12 @@ public class Config {
                 1,
                 100,
                 "Percentage added to base percentage per level of Beheading modifier");
+
+        headsFromFakePlayerKills = configfile.getBoolean(
+                "headsFromFakePlayerKills",
+                CATEGORY_Heads,
+                false,
+                "Drop heads when mobs are killed by a fake player");
 
         /** Vanilla/TConstruct Tweaks **/
         configfile.setCategoryComment(

--- a/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
@@ -152,7 +152,7 @@ public class Config {
         allowFakePlayerLeveling = configfile.getBoolean(
                 "allowFakePlayerLeveling",
                 CATEGORY_Leveling,
-                false,
+                true,
                 "Allow tool leveling through fake players");
 
         // tooltip things


### PR DESCRIPTION
This PR adds config options that allow FakePlayers to execute tasks that were previously only allowed to be done by real players. These options were added to all places where the limitation to real players was present (I searched for all mentions of the forge FakePlayer in the mod).

This results in two new config options:
- Allow tool leveling to be done by fake players
- Allow drops of mob heads through fake players (if the Iguana module "MobHeads" is active, not the case for GTNH)

The config options are defaulted to false, meaning there will be no changes in behavior unless explicitly wanted.
I made this feature mainly for my own modpack, though it might be worth considering to enable this in GTNH.

Tool leveling with FakePlayers was possible in GTNH until recently, as the Dynamism Tablet from ThaumicTinkerer bypassed the FakePlayer check present here by using `FakeThaumcraftPlayer` instead. The PR [ThaumicTinkerer#65](https://github.com/GTNewHorizons/ThaumicTinkerer/pull/65) changed that behaviour in favour of the Forge FakePlayer. This can be considered a bug, though its arguably mostly a game-design decision whether something like this should be allowed or not. (Which is why I made it a config option!)