### PR TITLE
Capped Tinkers weapon XP gain to actual damage dealt

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
@@ -66,8 +66,11 @@ public class LevelingEventHandler {
 
         int xp = 0;
         // is a weapon?
-        if (Arrays.asList(((ToolCore) stack.getItem()).getTraits()).contains("weapon")) xp = Math.round(event.ammount);
-        else xp = Math.round((event.ammount - 0.1f) / 2);
+        if (Arrays.asList(((ToolCore) stack.getItem()).getTraits()).contains("weapon")) {
+            int damageDealt = Math.round(event.ammount);
+            int mobHealth = Math.round(event.entityLiving.prevHealth);
+            xp = Math.min(damageDealt, mobHealth);
+        } else xp = Math.round((event.ammount - 0.1f) / 2);
 
         // reduce xp for hitting poor animals
         if (event.entityLiving instanceof EntityAnimal) xp = Math.max(1, xp / 2);


### PR DESCRIPTION
Tinkers weapons gained EXP based on the damage dealt to the enemy, regardless of how much of that is overkill. High damage weapons (crossbows) gained EXP really fast making them even stronger even faster.

This change makes tinkers weapons only gain EXP for the damage they actually deal, no overkill XP.