### PR TITLE
Swapping parts instead of AmmoItem repair

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ModPartReplacement.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ModPartReplacement.java
@@ -24,6 +24,7 @@ import tconstruct.library.modifier.ItemModifier;
 import tconstruct.library.tools.DualMaterialToolPart;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.library.util.IToolPart;
+import tconstruct.library.weaponry.AmmoItem;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.TinkerWeaponry;
 
@@ -50,6 +51,9 @@ public class ModPartReplacement extends ItemModifier {
         if (tags.getBoolean("Special")) return false;
 
         if (tags.getInteger("Damage") > 0) return false;
+        // Durability is written on "Ammo" tag instead of "Damage" tag for AmmoWeapons
+        if (tool instanceof AmmoItem && ((AmmoItem) tool).getMaxAmmo(tags) != ((AmmoItem) tool).getAmmoCount(itemStack))
+            return false;
 
         // check if any of the tools parts contain stone. we have to prevent exchanging that with disabled stone tools
         // because otherwise the replacement-logic would not be able to obtain necessary information and crash.

--- a/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
@@ -140,7 +140,7 @@ public final class ReplacementLogic {
         updateTag(newTags, tags, "HarvestLevelHandle");
         updateTag(newTags, tags, "HarvestLevelExtra");
 
-        // ranged weapons have have additional tags to consider
+        // ranged weapons have additional tags to consider
         updateTag(newTags, tags, "DrawSpeed");
         updateTag(newTags, tags, "BaseDrawSpeed");
         updateTag(newTags, tags, "FlightSpeed");
@@ -224,7 +224,7 @@ public final class ReplacementLogic {
                 xp *= (100.0f - Config.partReplacementXpPenality) / 100.0f;
             }
 
-            tags.setInteger(LevelingLogic.TAG_EXP, Math.round(xp));
+            tags.setLong(LevelingLogic.TAG_EXP, Math.round(xp));
         }
 
         // handle boost leveling/xp
@@ -245,7 +245,7 @@ public final class ReplacementLogic {
                 xp *= (100.0f - Config.partReplacementBoostXpPenality) / 100.0f;
             }
 
-            tags.setInteger(LevelingLogic.TAG_BOOST_EXP, Math.round(xp));
+            tags.setLong(LevelingLogic.TAG_BOOST_EXP, Math.round(xp));
 
             // already full xp?
             if (LevelingLogic.isBoosted(tags)) tags.setInteger("HarvestLevel", tags.getInteger("HarvestLevel") + 1);


### PR DESCRIPTION
Because AmmoItem durabilities are held in "Ammo" key and not in "Damage" as other tools, it wasn't checking for it in the replacement logic and replacing tool parts instead of repairing them, this is mainly issue with items that can be repaired with a valid tool material for example a throwing knife with bone head and wooden stick, would become bone head with bone stick instead of getting its ammo replenished.

This needs similar PRs to TinkersGregworks and TinkersConstruct-GTNH mods, but they shouldnt be needed for this to be merged so I'll not link them here.

but it would also solve this issue if this and aforementioned PRs gets merged, https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24330 . There is another pull request waiting for the same issue specifically but this one is needed to fix the part replacement problem.

I tested it in the latest daily and didnt see any issues, though I don't think the code change is something that would cause issues