### PR TITLE
Add Backhand compatibility for ranged Tinkers Weapons

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,11 +1,12 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:TinkersConstruct:1.14.58-GTNH:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")
+    api("com.github.GTNewHorizons:TinkersConstruct:1.14.72-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.8.98-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:TinkersGregworks:GTNH-1.0.33:dev")
     compileOnly("com.github.GTNewHorizons:Railcraft:9.17.26:dev")
-    compileOnly("com.github.GTNewHorizons:BuildCraft:7.1.57:dev")
+    compileOnly("com.github.GTNewHorizons:BuildCraft:7.1.60:dev")
+    compileOnly("com.github.GTNewHorizons:Backhand:1.8.10:dev")
 
     compileOnly("com.github.GTNewHorizons:Battlegear2:1.4.3:dev") {
         transitive = false
@@ -19,7 +20,7 @@ dependencies {
     compileOnly("curse.maven:cofh-core-69162:2388751")
 
     // For Debug Ruler, to view NBT
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:nei-custom-diagram:1.8.20:dev") {
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:nei-custom-diagram:1.8.27:dev") {
         transitive = false
     }
 }

--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
@@ -2,7 +2,6 @@ package iguanaman.iguanatweakstconstruct.leveling.handlers;
 
 import java.util.Arrays;
 
-import iguanaman.iguanatweakstconstruct.util.ModSupportHelper;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.monster.EntityBlaze;
@@ -29,6 +28,7 @@ import iguanaman.iguanatweakstconstruct.leveling.LevelingLogic;
 import iguanaman.iguanatweakstconstruct.leveling.LevelingTooltips;
 import iguanaman.iguanatweakstconstruct.leveling.RandomBonuses;
 import iguanaman.iguanatweakstconstruct.reference.Config;
+import iguanaman.iguanatweakstconstruct.util.ModSupportHelper;
 import tconstruct.items.tools.Chisel;
 import tconstruct.items.tools.Hammer;
 import tconstruct.items.tools.Pickaxe;
@@ -53,7 +53,7 @@ public class LevelingEventHandler {
         if (player instanceof FakePlayer && !Config.allowFakePlayerLeveling) return;
 
         ItemStack stack = player.getCurrentEquippedItem();
-        if (ModSupportHelper.Backhand){
+        if (ModSupportHelper.Backhand) {
             if (stack == null || !(stack.getItem() instanceof ToolCore)) {
                 stack = BackhandUtils.getOffhandItem(player);
             }

--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
@@ -2,7 +2,7 @@ package iguanaman.iguanatweakstconstruct.leveling.handlers;
 
 import java.util.Arrays;
 
-import cpw.mods.fml.common.Loader;
+import iguanaman.iguanatweakstconstruct.util.ModSupportHelper;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.monster.EntityBlaze;
@@ -53,7 +53,7 @@ public class LevelingEventHandler {
         if (player instanceof FakePlayer && !Config.allowFakePlayerLeveling) return;
 
         ItemStack stack = player.getCurrentEquippedItem();
-        if (Loader.isModLoaded("backhand")){
+        if (ModSupportHelper.Backhand){
             if (stack == null || !(stack.getItem() instanceof ToolCore)) {
                 stack = BackhandUtils.getOffhandItem(player);
             }

--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
@@ -2,6 +2,7 @@ package iguanaman.iguanatweakstconstruct.leveling.handlers;
 
 import java.util.Arrays;
 
+import cpw.mods.fml.common.Loader;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.monster.EntityBlaze;
@@ -52,8 +53,10 @@ public class LevelingEventHandler {
         if (player instanceof FakePlayer && !Config.allowFakePlayerLeveling) return;
 
         ItemStack stack = player.getCurrentEquippedItem();
-        if (stack == null || !(stack.getItem() instanceof ToolCore)) {
-            stack = BackhandUtils.getOffhandItem(player);
+        if (Loader.isModLoaded("backhand")){
+            if (stack == null || !(stack.getItem() instanceof ToolCore)) {
+                stack = BackhandUtils.getOffhandItem(player);
+            }
         }
 
         if (event.source.getSourceOfDamage() instanceof ShurikenEntity) {

--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
@@ -37,6 +37,7 @@ import tconstruct.library.tools.ToolCore;
 import tconstruct.library.weaponry.ProjectileWeapon;
 import tconstruct.weaponry.entity.ShurikenEntity;
 import tconstruct.weaponry.weapons.Shuriken;
+import xonin.backhand.api.core.BackhandUtils;
 
 public class LevelingEventHandler {
 
@@ -51,6 +52,10 @@ public class LevelingEventHandler {
         if (player instanceof FakePlayer && !Config.allowFakePlayerLeveling) return;
 
         ItemStack stack = player.getCurrentEquippedItem();
+        if (stack == null || !(stack.getItem() instanceof ToolCore)) {
+            stack = BackhandUtils.getOffhandItem(player);
+        }
+
         if (event.source.getSourceOfDamage() instanceof ShurikenEntity) {
             if (stack == null || !(stack.getItem() instanceof Shuriken)) {
                 if (player.inventory.currentItem == 0) stack = player.inventory.getStackInSlot(8);

--- a/src/main/java/iguanaman/iguanatweakstconstruct/util/ModSupportHelper.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/util/ModSupportHelper.java
@@ -14,6 +14,7 @@ public final class ModSupportHelper {
     public static final boolean Natura = Loader.isModLoaded("Natura");
     public static final boolean AppliedEnergistics2 = Loader.isModLoaded("appliedenergistics2");
     public static final boolean TGregworks = Loader.isModLoaded("TGregworks");
+    public static final boolean Backhand = Loader.isModLoaded("Backhand");
 
     public static final boolean ThermalFoundation = Loader.isModLoaded("ThermalFoundation");
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21602

Tinker's ranged weapons can be used in the Backhand slot, but previously did not gain EXP for damage dealt while there. This fixes that. Also updated dependencies and adds Backhand as a dependency.

Interestingly, ammo gaining exp in backhand slot already worked.