### PR TITLE
Enhance diamond level boost logic

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
@@ -27,12 +27,20 @@ public class ModBonusMiningLevel extends ItemModifier {
     protected boolean canModify(ItemStack input, ItemStack[] recipe) {
         NBTTagCompound tags = input.getTagCompound().getCompoundTag("InfiTool");
 
+        int curLevel = LevelingLogic.getHarvestLevel(tags);
+
         // only on bronze harvest level, if the config is true
-        if (LevelingLogic.getHarvestLevel(tags) != HarvestLevels._4_bronze && Config.diamondMinMiningLevelRequired)
-            return false;
+        if (curLevel != HarvestLevels._4_bronze && Config.diamondMinMiningLevelRequired) return false;
 
         // already applied? Only apply again if config is true
         if (tags.getBoolean(key) && !Config.diamondLevelBoostMultiple) return false;
+
+        // don't apply if boost is already maxxed out (prevents the consumption of without applying an effect)
+        int maxLevel = HarvestLevels._5_diamond;
+        // if it's emerald and it can be applied to any tool, not just bronze
+        maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired ? HarvestLevels._4_bronze
+                : HarvestLevels._5_diamond;
+        if (curLevel >= maxLevel) return false;
 
         // can be applied without modifier only if diamond/emerald modifier is already present
         if (tags.getInteger("Modifiers") <= 0 && !tags.getBoolean(parentTag)) return false;

--- a/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
@@ -36,9 +36,9 @@ public class ModBonusMiningLevel extends ItemModifier {
         if (tags.getBoolean(key) && !Config.diamondLevelBoostMultiple) return false;
 
         // don't apply if boost is already maxxed out (prevents the consumption of without applying an effect)
-        int maxLevel = HarvestLevels._5_diamond;
         // if it's emerald and it can be applied to any tool, not just bronze
-        maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired ? HarvestLevels._4_bronze
+        int maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired
+                ? HarvestLevels._4_bronze
                 : HarvestLevels._5_diamond;
         if (curLevel >= maxLevel) return false;
 
@@ -53,14 +53,14 @@ public class ModBonusMiningLevel extends ItemModifier {
     @Override
     public void modify(ItemStack[] input, ItemStack tool) {
         NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
-        int maxLevel = HarvestLevels._5_diamond;
 
         // if it's an emerald, max is bronze, not diamond.
         // but only as long as the config to make it applied to only bronze level tools is not true
         // because then we just keep the base iguana tweaks logic,
         // in which both diamond and emerald increased it to diamond mining level
-        if (this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired)
-            maxLevel = HarvestLevels._4_bronze;
+        int maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired
+                ? HarvestLevels._4_bronze
+                : HarvestLevels._5_diamond;
 
         // set to new harvest level, clamp to max
         int curLevel = LevelingLogic.getHarvestLevel(tags);

--- a/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
@@ -1,9 +1,12 @@
 package iguanaman.iguanatweakstconstruct.harvestlevels.modifiers;
 
+import static java.lang.Math.min;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 import iguanaman.iguanatweakstconstruct.leveling.LevelingLogic;
+import iguanaman.iguanatweakstconstruct.reference.Config;
 import iguanaman.iguanatweakstconstruct.util.HarvestLevels;
 import tconstruct.library.modifier.ItemModifier;
 
@@ -11,34 +14,54 @@ public class ModBonusMiningLevel extends ItemModifier {
 
     public final String parentTag;
 
+    // Adds a modifier with the same 'recipe' as diamond or emerald
+    // this new modifier is the one modifying harvest level, and is not modifying the base modifier
     public ModBonusMiningLevel(ItemStack[] recipe, String parentTag) {
         super(recipe, 0, "GemBoost");
 
         this.parentTag = parentTag;
     }
 
+    // when can it be applied
     @Override
     protected boolean canModify(ItemStack input, ItemStack[] recipe) {
         NBTTagCompound tags = input.getTagCompound().getCompoundTag("InfiTool");
 
-        // only on bronze harvest level
-        if (LevelingLogic.getHarvestLevel(tags) != HarvestLevels._4_bronze) return false;
+        // only on bronze harvest level, if the config is true
+        if (LevelingLogic.getHarvestLevel(tags) != HarvestLevels._4_bronze && Config.diamondMinMiningLevelRequired)
+            return false;
 
-        // already applied? (actually impossible, but maybe we'll change something in the future
-        if (tags.getBoolean(key)) return false;
+        // already applied? Only apply again if config is true
+        if (tags.getBoolean(key) && !Config.diamondLevelBoostMultiple) return false;
 
-        // can be applied without modifier if diamond/emerald modifier is already present
+        // can be applied without modifier only if diamond/emerald modifier is already present
         if (tags.getInteger("Modifiers") <= 0 && !tags.getBoolean(parentTag)) return false;
 
-        // only if harvestlevel is bronze and can NOT be boosted anymore
-        return !LevelingLogic.canBoostMiningLevel(tags);
+        // diamond (or emerald) level boost can be applied
+        return true;
     }
 
+    // what harvest level modification it should do in place of diamond/emerald's harvest level modification
     @Override
     public void modify(ItemStack[] input, ItemStack tool) {
         NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
-        // set harvestlevel to diamond
-        tags.setInteger("HarvestLevel", HarvestLevels._5_diamond);
+        int maxLevel = HarvestLevels._5_diamond;
+
+        // if it's an emerald, max is bronze, not diamond.
+        // but only as long as the config to make it applied to only bronze level tools is not true
+        // because then we just keep the base iguana tweaks logic,
+        // in which both diamond and emerald increased it to diamond mining level
+        if (this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired)
+            maxLevel = HarvestLevels._4_bronze;
+
+        // set to new harvest level, clamp to max
+        int curLevel = LevelingLogic.getHarvestLevel(tags);
+        if (curLevel < maxLevel) {
+            int modifiedLevel = curLevel + Config.diamondLevelAddition;
+            // just in case it's more than 1 level per diamond/emerald
+            modifiedLevel = min(modifiedLevel, maxLevel);
+            tags.setInteger("HarvestLevel", modifiedLevel);
+        }
 
         // no need to remove a modifier, since we either already have a diamond modifier or get it added together with
         // this modifier

--- a/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
@@ -284,7 +284,7 @@ public class Config {
                 1,
                 0,
                 9999,
-                "Changes the amount of mining levels Diamond and Emerald modifier add. Default 1. Will not exceed diamond/bronze level, respectively. Range: 0~9999");
+                "Changes the amount of mining levels Diamond and Emerald modifier add. Default 1. Will not exceed diamond/bronze level, respectively.");
 
         // change if it can be applied multiple times
         diamondLevelBoostMultiple = configfile.getBoolean(

--- a/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/reference/Config.java
@@ -47,6 +47,9 @@ public class Config {
 
     // Harvest Leveling
     public static boolean changeDiamondModifier;
+    public static boolean diamondMinMiningLevelRequired;
+    public static boolean diamondLevelBoostMultiple;
+    public static int diamondLevelAddition;
     public static int durabilityPercentage;
     public static int miningSpeedPercentage;
 
@@ -260,12 +263,35 @@ public class Config {
                 CATEGORY_HarvestLevels,
                 "Harvest Level Tweak Module: Introduces a slower mining level progression.");
 
-        // changed diamond/emerald modifier
+        // change diamond/emerald modifier acting capacity
         changeDiamondModifier = configfile.getBoolean(
-                "diamondRequired",
+                "changeDiamondModifier",
                 CATEGORY_HarvestLevels,
-                true,
-                "Changes the Diamond and Emerald modifier: Apply it to a bronze level tool to obtain diamond level. Required unless you have steel or similar.");
+                false,
+                "Whether to override Tinkers' Construct logic for diamond/emerald mining level increase.");
+
+        // change diamond/emerald modifier acting capacity
+        diamondMinMiningLevelRequired = configfile.getBoolean(
+                "diamondMinMiningLevelRequired",
+                CATEGORY_HarvestLevels,
+                false,
+                "Increases the mining level by diamondLevelAddition config of ONLY a tool with bronze (mines redstone) mining level. For when you do not have a steel or other alternative for diamond mining level, and have the other config off.");
+
+        // change amount of levels diamond/emerald modifier add
+        diamondLevelAddition = configfile.getInt(
+                "diamondLevelAddition",
+                CATEGORY_HarvestLevels,
+                1,
+                0,
+                9999,
+                "Changes the amount of mining levels Diamond and Emerald modifier add. Default 1. Will not exceed diamond/bronze level, respectively. Range: 0~9999");
+
+        // change if it can be applied multiple times
+        diamondLevelBoostMultiple = configfile.getBoolean(
+                "diamondLevelBoostMultiple",
+                CATEGORY_HarvestLevels,
+                false,
+                "Allows the boost from diamond/emerald to be applied multiple times, each time costing a diamond/emerald, but not a modifier");
 
         // Tool durability/speed changes
         durabilityPercentage = configfile.getInt(


### PR DESCRIPTION
Modify and modularize (and add comments for) the logic for the application of a mining/harvest level boost of a diamond and emerald modifier. 

The base logic only had the options to:
1. Use tinkers logic (set level to diamond/bronze)
2. Apply boost on only bronze tools, bringing them to diamond
3. or do nothing

This adds:
1. The ability to select how many levels the boost should add, to a max
2. Whether the boost can be added multiple times


~~draft because i just realised I should test it first (whoops)~~ done.

followup pr: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/25099