### PR TITLE
Fix validity check due to new logic for gem boost

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/OldToolConversionHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/OldToolConversionHandler.java
@@ -9,12 +9,12 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
+import iguanaman.iguanatweakstconstruct.harvestlevels.modifiers.ModBonusMiningLevel;
 import iguanaman.iguanatweakstconstruct.leveling.LevelingLogic;
 import iguanaman.iguanatweakstconstruct.mobheads.IguanaMobHeads;
 import iguanaman.iguanatweakstconstruct.reference.Config;
 import iguanaman.iguanatweakstconstruct.reference.Reference;
 import iguanaman.iguanatweakstconstruct.replacing.ReplacementLogic;
-import iguanaman.iguanatweakstconstruct.util.HarvestLevels;
 import iguanaman.iguanatweakstconstruct.util.Log;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.items.tools.Hammer;
@@ -74,21 +74,27 @@ public class OldToolConversionHandler {
         // check mining level.
         int realHlvl = TConstructRegistry.getMaterial(tags.getInteger("Head")).harvestLevel();
 
-        // unboosted but boost requires -> we need to reduce the hlvl by 1
+        // unboosted but boost required -> we need to reduce the hlvl by 1
         if (Config.pickaxeBoostRequired && !LevelingLogic.isBoosted(tags)
                 && (itemStack.getItem() instanceof Pickaxe || itemStack.getItem() instanceof Hammer)) {
             int min = 0;
+
+            // Tinkers' native logic, which sets the level
             if (PHConstruct.miningLevelIncrease) {
                 if (tags.getBoolean("Diamond")) min = 3;
                 else if (tags.getBoolean("Emerald")) min = 2;
+            }
+            // Iguana logic, which is a bit more modular
+            else if (Config.changeDiamondModifier) {
+                min = ModBonusMiningLevel.gemBoostedLevel(tags);
             }
 
             return hlvl != Math.max(realHlvl - 1, min);
         }
 
-        // if it's boosted, check if it's boosted by a diamond from bronze level
-        if (tags.hasKey("GemBoost") && realHlvl == HarvestLevels._4_bronze) {
-            return hlvl != HarvestLevels._5_diamond;
+        // check if it's boosted by a gemBoost
+        if (tags.hasKey("GemBoost")) {
+            return hlvl != ModBonusMiningLevel.gemBoostedLevel(tags);
         }
 
         // vanilla tcon allows harvestlevel change
@@ -135,7 +141,7 @@ public class OldToolConversionHandler {
         // recreate the head itemstack
         ItemStack newHead = new ItemStack(tool.getHeadItem(), 1, tags.getInteger("Head"));
 
-        // bolts are special..
+        // bolts are special
         if (tool instanceof BoltAmmo) newHead = DualMaterialToolPart
                 .createDualMaterial(tool.getHeadItem(), tags.getInteger("Handle"), tags.getInteger("Head"));
 

--- a/src/main/java/iguanaman/iguanatweakstconstruct/OldToolConversionHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/OldToolConversionHandler.java
@@ -68,11 +68,10 @@ public class OldToolConversionHandler {
         // we don't need to check for xp, since if it has a level, it has xp.
         // but we need to check for boosting xp
         int hlvl = tags.getInteger("HarvestLevel");
-        if (hlvl > 0 && (itemStack.getItem() instanceof Pickaxe || itemStack.getItem() instanceof Hammer))
-            if (!LevelingLogic.hasBoostXp(tags) && Config.pickaxeBoostRequired) return true;
-
-        // check mining level.
+        // actual mining level of head, pre-boosts
         int realHlvl = TConstructRegistry.getMaterial(tags.getInteger("Head")).harvestLevel();
+        if (hlvl > 0 && (itemStack.getItem() instanceof Pickaxe || itemStack.getItem() instanceof Hammer))
+            if (!LevelingLogic.hasBoostXp(tags) && Config.pickaxeBoostRequired && realHlvl != 0) return true;
 
         // unboosted but boost required -> we need to reduce the hlvl by 1
         if (Config.pickaxeBoostRequired && !LevelingLogic.isBoosted(tags)
@@ -83,9 +82,8 @@ public class OldToolConversionHandler {
             if (PHConstruct.miningLevelIncrease) {
                 if (tags.getBoolean("Diamond")) min = 3;
                 else if (tags.getBoolean("Emerald")) min = 2;
-            }
-            // Iguana logic, which is a bit more modular
-            else if (Config.changeDiamondModifier) {
+            } else if (Config.changeDiamondModifier) {
+                // Iguana logic, which is a bit more modular
                 min = ModBonusMiningLevel.gemBoostedLevel(tags);
             }
 
@@ -118,6 +116,7 @@ public class OldToolConversionHandler {
     public static void updateItem(ItemStack itemStack) {
         ToolCore tool = (ToolCore) itemStack.getItem();
         NBTTagCompound tags = itemStack.getTagCompound().getCompoundTag("InfiTool");
+        int gemBoost = tags.hasKey("GemBoost") ? tags.getInteger("GemBoost") : 0;
 
         // Special check for broken attack-modifier from ITT levelups (see above)
         // Special check for all the weapons that got broken from the Attack-Modifier bug
@@ -153,6 +152,11 @@ public class OldToolConversionHandler {
         Config.partReplacementBoostXpPenality = 0;
 
         ReplacementLogic.exchangeToolPart(tool, tags, ReplacementLogic.PartTypes.HEAD, newHead, itemStack);
+        // re-add gem boost, since it's not an actual part replacement
+        if (gemBoost > 0) {
+            tags.setInteger("GemBoost", gemBoost);
+            tags.setInteger("HarvestLevel", tags.getInteger("HarvestLevel") + gemBoost);
+        }
 
         Config.partReplacementXpPenality = oldXpPenality;
         Config.partReplacementBoostXpPenality = oldBoostXpPenality;

--- a/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
@@ -1,5 +1,6 @@
 package iguanaman.iguanatweakstconstruct.harvestlevels.modifiers;
 
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 import net.minecraft.item.ItemStack;
@@ -8,6 +9,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import iguanaman.iguanatweakstconstruct.leveling.LevelingLogic;
 import iguanaman.iguanatweakstconstruct.reference.Config;
 import iguanaman.iguanatweakstconstruct.util.HarvestLevels;
+import tconstruct.library.TConstructRegistry;
 import tconstruct.library.modifier.ItemModifier;
 
 public class ModBonusMiningLevel extends ItemModifier {
@@ -33,14 +35,10 @@ public class ModBonusMiningLevel extends ItemModifier {
         if (curLevel != HarvestLevels._4_bronze && Config.diamondMinMiningLevelRequired) return false;
 
         // already applied? Only apply again if config is true
-        if (tags.getBoolean(key) && !Config.diamondLevelBoostMultiple) return false;
+        if (tags.getInteger(key) > 0 && !Config.diamondLevelBoostMultiple) return false;
 
         // don't apply if boost is already maxxed out (prevents the consumption of without applying an effect)
-        // if it's emerald and it can be applied to any tool, not just bronze
-        int maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired
-                ? HarvestLevels._4_bronze
-                : HarvestLevels._5_diamond;
-        if (curLevel >= maxLevel) return false;
+        if (curLevel >= this.maxHarvestLvl(tags)) return false;
 
         // can be applied without modifier only if diamond/emerald modifier is already present
         if (tags.getInteger("Modifiers") <= 0 && !tags.getBoolean(parentTag)) return false;
@@ -54,27 +52,74 @@ public class ModBonusMiningLevel extends ItemModifier {
     public void modify(ItemStack[] input, ItemStack tool) {
         NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
 
-        // if it's an emerald, max is bronze, not diamond.
-        // but only as long as the config to make it applied to only bronze level tools is not true
-        // because then we just keep the base iguana tweaks logic,
-        // in which both diamond and emerald increased it to diamond mining level
-        int maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired
-                ? HarvestLevels._4_bronze
-                : HarvestLevels._5_diamond;
+        int maxLevel = this.maxHarvestLvl(tags);
+        int actualBoost = 0;
 
         // set to new harvest level, clamp to max
         int curLevel = LevelingLogic.getHarvestLevel(tags);
         if (curLevel < maxLevel) {
-            int modifiedLevel = curLevel + Config.diamondLevelAddition;
-            // just in case it's more than 1 level per diamond/emerald
-            modifiedLevel = min(modifiedLevel, maxLevel);
+            // get how many levels are being added, if less than config amount
+            actualBoost = Math.min(maxLevel - curLevel, Config.diamondLevelAddition);
+            // use the actual boost, so we don't go over the max
+            int modifiedLevel = curLevel + actualBoost;
             tags.setInteger("HarvestLevel", modifiedLevel);
         }
 
         // no need to remove a modifier, since we either already have a diamond modifier or get it added together with
         // this modifier
-        // but we have to add the key
-        tags.setBoolean(key, true);
+        // but we have to add the key, and how many levels it has added
+        if (tags.hasKey(key)) {
+            tags.setInteger(key, tags.getInteger(key) + actualBoost);
+        } else tags.setInteger(key, Config.diamondLevelAddition);
+    }
+
+    public int maxHarvestLvl(NBTTagCompound tags) {
+        /*
+         * if it's an emerald, max is bronze, not diamond. but only as long as the config to make it applied to only
+         * bronze level tools is not true because then we just keep the base iguana tweaks logic, in which both diamond
+         * and emerald increased it to diamond
+         */
+        int maxLvl = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired ? HarvestLevels._4_bronze
+                : HarvestLevels._5_diamond;
+
+        /*
+         * if boosting is needed, and the pick isn't boosted yet, lower max by 1. Prevents it from getting an extra
+         * mining level when it shouldn't. I.e., you boost it to diamond with a bunch of diamonds, then boost it with
+         * boostXP or a head, it'll have obsidian harvest level (mines ardite)
+         */
+        if (LevelingLogic.isBoosted(tags) && Config.pickaxeBoostRequired) {
+            maxLvl -= 1;
+        }
+
+        return maxLvl;
+    }
+
+    public static int gemBoostedLevel(NBTTagCompound tags) {
+        int headLvl = TConstructRegistry.getMaterial(tags.getInteger("Head")).harvestLevel();
+        boolean isBoosted = LevelingLogic.isBoosted(tags) && Config.pickaxeBoostRequired;
+
+        if (!isBoosted) {
+            headLvl -= 1;
+        }
+
+        if (tags.hasKey("GemBoost")) {
+            int boostedLvl = headLvl + tags.getInteger("GemBoost");
+
+            int max = 0;
+            if (tags.getBoolean("Diamond")) max = HarvestLevels._5_diamond;
+            else if (tags.getBoolean("Emerald"))
+                max = !Config.diamondMinMiningLevelRequired ? HarvestLevels._4_bronze : HarvestLevels._5_diamond;
+
+            if (!isBoosted) {
+                max--;
+            }
+
+            // return head level if it's the highest
+            // otherwise, clamp it to the max between head + boost and the max boost
+            return max(headLvl, min(boostedLvl, max));
+        }
+
+        return headLvl;
     }
 
     @Override

--- a/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
@@ -38,7 +38,15 @@ public class ModBonusMiningLevel extends ItemModifier {
         if (tags.getInteger(key) > 0 && !Config.diamondLevelBoostMultiple) return false;
 
         // don't apply if boost is already maxxed out (prevents the consumption of without applying an effect)
-        if (curLevel >= this.maxHarvestLvl(tags)) return false;
+        // if it's emerald and it can be applied to any tool, not just bronze
+        int maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired
+                ? HarvestLevels._4_bronze
+                : HarvestLevels._5_diamond;
+        // if it's not boosted, subtract 1 so it doesn't do more than it should
+        if (!LevelingLogic.isBoosted(tags) && Config.pickaxeBoostRequired) {
+            maxLevel -= 1;
+        }
+        if (curLevel >= maxLevel) return false;
 
         // can be applied without modifier only if diamond/emerald modifier is already present
         if (tags.getInteger("Modifiers") <= 0 && !tags.getBoolean(parentTag)) return false;
@@ -52,7 +60,19 @@ public class ModBonusMiningLevel extends ItemModifier {
     public void modify(ItemStack[] input, ItemStack tool) {
         NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
 
-        int maxLevel = this.maxHarvestLvl(tags);
+        // if it's an emerald, max is bronze, not diamond.
+        // but only as long as the config to make it applied to only bronze level tools is not true
+        // because then we just keep the base iguana tweaks logic,
+        // in which both diamond and emerald increased it to diamond mining level
+        int maxLevel = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired
+                ? HarvestLevels._4_bronze
+                : HarvestLevels._5_diamond;
+        // if it's not boosted, subtract 1 so it doesn't do more than it should
+        // I.e., you boost it to diamond with a bunch of diamonds, then boost it with
+        // boostXP or a head, it'll have obsidian harvest level (mines ardite)
+        if (!LevelingLogic.isBoosted(tags) && Config.pickaxeBoostRequired) {
+            maxLevel -= 1;
+        }
         int actualBoost = 0;
 
         // set to new harvest level, clamp to max
@@ -73,32 +93,11 @@ public class ModBonusMiningLevel extends ItemModifier {
         } else tags.setInteger(key, Config.diamondLevelAddition);
     }
 
-    public int maxHarvestLvl(NBTTagCompound tags) {
-        /*
-         * if it's an emerald, max is bronze, not diamond. but only as long as the config to make it applied to only
-         * bronze level tools is not true because then we just keep the base iguana tweaks logic, in which both diamond
-         * and emerald increased it to diamond
-         */
-        int maxLvl = this.parentTag.equals("Emerald") && !Config.diamondMinMiningLevelRequired ? HarvestLevels._4_bronze
-                : HarvestLevels._5_diamond;
-
-        /*
-         * if boosting is needed, and the pick isn't boosted yet, lower max by 1. Prevents it from getting an extra
-         * mining level when it shouldn't. I.e., you boost it to diamond with a bunch of diamonds, then boost it with
-         * boostXP or a head, it'll have obsidian harvest level (mines ardite)
-         */
-        if (LevelingLogic.isBoosted(tags) && Config.pickaxeBoostRequired) {
-            maxLvl -= 1;
-        }
-
-        return maxLvl;
-    }
-
     public static int gemBoostedLevel(NBTTagCompound tags) {
         int headLvl = TConstructRegistry.getMaterial(tags.getInteger("Head")).harvestLevel();
         boolean isBoosted = LevelingLogic.isBoosted(tags) && Config.pickaxeBoostRequired;
 
-        if (!isBoosted) {
+        if (!isBoosted && headLvl != 0) {
             headLvl -= 1;
         }
 
@@ -110,7 +109,7 @@ public class ModBonusMiningLevel extends ItemModifier {
             else if (tags.getBoolean("Emerald"))
                 max = !Config.diamondMinMiningLevelRequired ? HarvestLevels._4_bronze : HarvestLevels._5_diamond;
 
-            if (!isBoosted) {
+            if (!isBoosted && max != 0) {
                 max--;
             }
 

--- a/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/modifiers/ModBonusMiningLevel.java
@@ -93,6 +93,7 @@ public class ModBonusMiningLevel extends ItemModifier {
         } else tags.setInteger(key, Config.diamondLevelAddition);
     }
 
+    // The level it should be with the gem boosts
     public static int gemBoostedLevel(NBTTagCompound tags) {
         int headLvl = TConstructRegistry.getMaterial(tags.getInteger("Head")).harvestLevel();
         boolean isBoosted = LevelingLogic.isBoosted(tags) && Config.pickaxeBoostRequired;

--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/LevelingLogic.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/LevelingLogic.java
@@ -95,7 +95,7 @@ public final class LevelingLogic {
     /**
      * Add the leveling specific NBT.
      * 
-     * @param tag The tag that should recieve the data. Usually InfiTool Tag.
+     * @param tag The tag that should receive the data. Usually InfiTool Tag.
      */
     public static void addLevelingTags(NBTTagCompound tag, ToolCore tool) {
         // we start with level 1

--- a/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/replacing/ReplacementLogic.java
@@ -191,6 +191,7 @@ public final class ReplacementLogic {
         if (Config.removeMobHeadOnPartReplacement && type == HEAD) removeMobHeadModifier(tags);
 
         // if boosted, remove boost tag
+        // you're removing the head that had the reinforced tips or w/e after all
         if (tags.hasKey("GemBoost")) tags.removeTag("GemBoost");
 
         // if boosted by vanilla diamond modifier, then we have to respect that if vanilla tcon allows harvestlevel


### PR DESCRIPTION
Fix validity check due to new logic for gem boost, https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/35

got a jumpscare from 
<img width="538" height="259" alt="image" src="https://github.com/user-attachments/assets/48dd7943-0682-4d47-9100-f778eb6705fb" />


Is fixed now. Tested with a lot of variations on the configs, including multiple harvest levels being added, whether it required bronze mining level to work at all, etc.